### PR TITLE
Mount udev database into container

### DIFF
--- a/staging/docker-compose.yml
+++ b/staging/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       context: "../exporter"
     volumes:
       - "./exporter-conf:/opt/exporter-conf"
+      - "/run/udev:/run/udev:ro"
     devices:
       - "/dev/ttyUSB0:/dev/ttyUSB0"
     networks:


### PR DESCRIPTION
Labgrids udev matching via ID_*
http://labgrid.readthedocs.io/en/latest/getting_started.html#udev-matching
requires to mount the udev database inside the container, see
https://stackoverflow.com/a/44443367