### PR TITLE
make /tmp a tmpfs for the client

### DIFF
--- a/staging/docker-compose.yml
+++ b/staging/docker-compose.yml
@@ -9,6 +9,7 @@ services:
   client:
     build:
       context: "../client"
+    tmpfs: "/tmp"
     networks:
       - labgrid_net
     tty: true


### PR DESCRIPTION
The labgrid sshdriver uses control sockets on /tmp There is a known bug that causes the connection to be refused if the control socket is created on an overlayfs. To avoid this problem, we should make /tmp a tmpfs.

https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1262287